### PR TITLE
Fix hydration mismatch in chart component

### DIFF
--- a/src/components/chart-loading-skeleton.tsx
+++ b/src/components/chart-loading-skeleton.tsx
@@ -1,5 +1,59 @@
 import React from 'react';
 
+// Predefined values to avoid hydration mismatch
+const chartBarData = [
+  { height: 70.61, opacity: 0.306 },
+  { height: 25.73, opacity: 0.626 },
+  { height: 38.15, opacity: 0.513 },
+  { height: 54.59, opacity: 0.336 },
+  { height: 62.61, opacity: 0.362 },
+  { height: 76.79, opacity: 0.415 },
+  { height: 25.96, opacity: 0.320 },
+  { height: 45.09, opacity: 0.327 },
+  { height: 58.20, opacity: 0.534 },
+  { height: 74.21, opacity: 0.623 },
+  { height: 78.88, opacity: 0.399 },
+  { height: 49.48, opacity: 0.554 },
+  { height: 63.88, opacity: 0.329 },
+  { height: 52.73, opacity: 0.622 },
+  { height: 29.42, opacity: 0.341 },
+  { height: 24.30, opacity: 0.537 },
+  { height: 71.84, opacity: 0.402 },
+  { height: 21.84, opacity: 0.319 },
+  { height: 37.95, opacity: 0.574 },
+  { height: 78.40, opacity: 0.432 },
+  { height: 30.42, opacity: 0.533 },
+  { height: 29.44, opacity: 0.482 },
+  { height: 36.96, opacity: 0.673 },
+  { height: 72.05, opacity: 0.675 },
+  { height: 24.33, opacity: 0.590 },
+  { height: 67.20, opacity: 0.677 },
+  { height: 70.46, opacity: 0.519 },
+  { height: 28.18, opacity: 0.660 },
+  { height: 27.36, opacity: 0.301 },
+  { height: 53.20, opacity: 0.537 },
+  { height: 59.94, opacity: 0.322 },
+  { height: 48.34, opacity: 0.608 },
+  { height: 35.58, opacity: 0.359 },
+  { height: 53.75, opacity: 0.474 },
+  { height: 25.51, opacity: 0.346 },
+  { height: 66.26, opacity: 0.369 },
+  { height: 25.17, opacity: 0.403 },
+  { height: 34.91, opacity: 0.674 },
+  { height: 62.93, opacity: 0.344 },
+  { height: 55.71, opacity: 0.321 },
+  { height: 52.35, opacity: 0.309 },
+  { height: 78.47, opacity: 0.325 },
+  { height: 49.32, opacity: 0.382 },
+  { height: 65.24, opacity: 0.597 },
+  { height: 49.70, opacity: 0.586 },
+  { height: 26.73, opacity: 0.506 },
+  { height: 69.77, opacity: 0.566 },
+  { height: 68.56, opacity: 0.462 },
+  { height: 47.79, opacity: 0.479 },
+  { height: 67.37, opacity: 0.455 },
+];
+
 const ChartLoadingSkeleton = () => {
   return (
     <div className="h-full w-full bg-card border rounded-lg p-4 animate-pulse">
@@ -28,13 +82,13 @@ const ChartLoadingSkeleton = () => {
         
         {/* Chart bars/candles simulation */}
         <div className="absolute bottom-8 left-4 right-16 flex items-end space-x-1">
-          {Array.from({ length: 50 }, (_, i) => (
+          {chartBarData.map((bar, i) => (
             <div
               key={i}
               className="bg-gray-300 rounded-sm flex-1"
               style={{
-                height: `${Math.random() * 60 + 20}%`,
-                opacity: 0.3 + Math.random() * 0.4,
+                height: `${bar.height}%`,
+                opacity: bar.opacity,
               }}
             />
           ))}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix hydration mismatch in `ChartLoadingSkeleton` by using predefined values for bar heights and opacities.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation used `Math.random()` to generate dynamic styles for the chart bars, which resulted in different values between server-side rendering and client-side hydration, causing React to report a hydration mismatch error. This change ensures deterministic rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-259a45b8-037b-477c-a758-09915a239864">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-259a45b8-037b-477c-a758-09915a239864">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>